### PR TITLE
OXT-1829 Mark child devices as missing if xenstore query fails

### DIFF
--- a/src/xenvusb/bus.c
+++ b/src/xenvusb/bus.c
@@ -522,7 +522,15 @@ BusEvtChildListScanForChildren(
 
     if (!NT_SUCCESS(status))
     {
-        Info("Failed to perform directory in xenstore.\n");
+        /* This callback has a duty to update PnP of child devices. Since this
+         * is called after a USB has been removed, hotplugged or otherwise, the event channel can
+         * be torn down when called. Mark devices as missing and return. For more info:
+         *
+         * https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdfchildlist/nc-wdfchildlist-evt_wdf_child_list_scan_for_children
+         */
+        Info("Failed to perform xenstore query. Marking child devices as missing to PnP.\n");
+        WdfChildListBeginScan(ChildList);
+        WdfChildListEndScan(ChildList);
         return;
     }
 


### PR DESCRIPTION
When the guest awakes from sleep and a USB was removed, the device still
appears in the WDF framework, showing up in device manager and file
explorer. Without this change, the child list reports no changes even
though a child device was removed.

Signed-off-by: Bryer Esengard <esengardb@ainfosec.com>